### PR TITLE
Fix deprecation warning for arity of `initialize`

### DIFF
--- a/addon/initializers/seo.js
+++ b/addon/initializers/seo.js
@@ -1,7 +1,7 @@
 /*jshint esversion: 6 */
 import Ember from 'ember';
 
-export function initialize(container,app){}
+export function initialize(app){}
 
 var get, set;
 


### PR DESCRIPTION
This change fixes an Ember deprecation warning when calling
`initialize`. It now takes just one argument, an Ember application,
rather than a container and an application.

Documentation:
https://emberjs.com/deprecations/v2.x/#toc_initializer-arity

Fix #3.